### PR TITLE
chore: remove busybox 1.30 - already installed on alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,22 @@
-FROM ruby:2.6-alpine
-
-# CVE-2019-5747 Can remove when base image includes busybox version 1.30.0
-RUN wget https://busybox.net/downloads/binaries/1.30.0-i686/busybox && chmod +x busybox && mv busybox /bin/busybox
+FROM ruby:2.6.4-alpine
 
 # Installation path
 ENV HOME=/pact_broker
 
 # Setup ruby user & install application dependencies
 RUN set -ex && \
-    adduser -h $HOME -s /bin/false -D -S -G root ruby && \
-    chmod g+w $HOME && \
-    apk add --update --no-cache make gcc libc-dev mariadb-dev postgresql-dev sqlite-dev
+  adduser -h $HOME -s /bin/false -D -S -G root ruby && \
+  chmod g+w $HOME && \
+  apk add --update --no-cache make gcc libc-dev mariadb-dev postgresql-dev sqlite-dev
 
 # Install Gems
 WORKDIR $HOME
 COPY pact_broker/Gemfile pact_broker/Gemfile.lock $HOME/
 RUN set -ex && \
-    gem install bundler -v 2.0.2 && \
-    bundle install --no-cache --deployment --without='development test' && \
-    rm -rf vendor/bundle/ruby/*/cache .bundle/cache && \
-    apk del make gcc libc-dev
+  gem install bundler -v 2.0.2 && \
+  bundle install --no-cache --deployment --without='development test' && \
+  rm -rf vendor/bundle/ruby/*/cache .bundle/cache && \
+  apk del make gcc libc-dev
 
 # Install source
 COPY pact_broker $HOME/


### PR DESCRIPTION
Should we peg to `ruby:2.6.4-alpine` instead of `ruby:2.6-alpine`?