### PR TITLE
Update docker-compose to persist postgres data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       test: psql postgres --command "select 1" -U postgres
     ports:
       - "5432:5432"
+    volumes:
+      - postgres-volume:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
@@ -39,3 +41,5 @@ services:
     ports:
       - "8443:443"
       - "80:80"
+volumes:
+  postgres-volume:


### PR DESCRIPTION
**Description** :

Typically we don't have to clean up Postgres data whenever we bring down the Postgres service in general unless there is a different use-case we want to achieve.

- What are we changing here? 
Updating Docker compose to use volumes for Postgres so that every time we bring back the docker services we use the existing volume on the system.

```
Logs will look like below

pact_broker_1  | Puma starting in single mode...
pact_broker_1  | * Version 3.12.2 (ruby 2.6.4-p104), codename: Llamas in Pajamas
pact_broker_1  | * Min threads: 0, max threads: 16
postgres_1     |
postgres_1     | PostgreSQL Database directory appears to contain a database; Skipping initialization
postgres_1     |
pact_broker_1  | * Environment: production

```

