### PR TITLE
feat(deps): Update puma to 5.3.1

### DIFF
--- a/pact_broker/Gemfile
+++ b/pact_broker/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem "pact_broker"
 gem "pg", "~>1.0"
-gem "puma", "~> 4.3", ">= 4.3.8"
+gem "puma", "~> 5.3"
 gem "mysql2", "~>0.3"
 gem "sqlite3", "~>1.3"
 gem "rake", "~> 13.0"

--- a/pact_broker/Gemfile.lock
+++ b/pact_broker/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       thor (~> 0.18)
     padrino-support (0.15.0)
     pg (1.2.3)
-    puma (4.3.8)
+    puma (5.3.1)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -161,7 +161,7 @@ DEPENDENCIES
   mysql2 (~> 0.3)
   pact_broker
   pg (~> 1.0)
-  puma (~> 4.3, >= 4.3.8)
+  puma (~> 5.3)
   rake (~> 13.0)
   sqlite3 (~> 1.3)
   webrick (~> 1.6)


### PR DESCRIPTION
Upgrade to latest puma version. Amongst the other it extends the maximum path length from 2k to 8k, which let us use custom (base64 encoded data) as version names. 