### PR TITLE
Adds Pact Broker Helm Chart

### DIFF
--- a/charts/Chart.lock
+++ b/charts/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.6.2
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.16.0
+digest: sha256:91802876836d50ce38519987ba8fa5f1cdb28dacb2a1cc4959fb8b85c625921f
+generated: "2022-06-03T20:42:48.159689+01:00"

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: pact-broker
+description: The Pact Broker is an application for sharing for Pact contracts and verification results
+type: application
+version: 0.0.1
+appVersion: 2.100.0.1
+dependencies:
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 11.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+sources:
+  - https://github.com/pact-foundation/pact_broker

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,150 @@
+# pact-broker
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.100.0.1](https://img.shields.io/badge/AppVersion-2.100.0.1-informational?style=flat-square)
+
+The Pact Broker is an application for sharing for Pact contracts and verification results
+
+## Source Code
+
+* <https://github.com/pact-foundation/pact_broker>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://charts.bitnami.com/bitnami | postgresql | 11.x.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| broker | object | `{"annotations":{},"config":{"basicAuth":{"allowPublicRead":false,"enablePublicBadgeAccess":false,"publicHeartbeat":true,"readUser":{"existingSecret":"","existingSecretPasswordKey":"","existingSecretUsernameKey":"","password":"admin","username":"admin"},"writeUser":{"existingSecret":"","existingSecretPasswordKey":"","existingSecretUsernameKey":"","password":"admin","username":"admin"}},"disable_ssl":false},"containerPorts":{"http":9292,"https":8443},"containerSecurityContext":{"enabled":true,"runAsNonRoot":true,"runAsUser":1001},"labels":{},"livenessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":300,"periodSeconds":1,"successThreshold":1,"timeoutSeconds":5},"podSecurityContext":{"enabled":true,"fsGroup":1001},"readinessProbe":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1},"replicaCount":1,"resources":{"limits":{"cpu":"2500m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}}` | Broker configuration  |
+| broker.annotations | object | `{}` | Additional annotations that can be added to the Broker deployment |
+| broker.config | object | `{"basicAuth":{"allowPublicRead":false,"enablePublicBadgeAccess":false,"publicHeartbeat":true,"readUser":{"existingSecret":"","existingSecretPasswordKey":"","existingSecretUsernameKey":"","password":"admin","username":"admin"},"writeUser":{"existingSecret":"","existingSecretPasswordKey":"","existingSecretUsernameKey":"","password":"admin","username":"admin"}},"disable_ssl":false}` | Pact Broker Config |
+| broker.config.basicAuth | object | `{"allowPublicRead":false,"enablePublicBadgeAccess":false,"publicHeartbeat":true,"readUser":{"existingSecret":"","existingSecretPasswordKey":"","existingSecretUsernameKey":"","password":"admin","username":"admin"},"writeUser":{"existingSecret":"","existingSecretPasswordKey":"","existingSecretUsernameKey":"","password":"admin","username":"admin"}}` | Pact Broker Basic Authentication |
+| broker.config.basicAuth.allowPublicRead | bool | `false` | Set to true if you want public read access, but still require credentials for writing.  |
+| broker.config.basicAuth.enablePublicBadgeAccess | bool | `false` | Set this to true to allow status badges to be embedded in README files without requiring a hardcoded password. |
+| broker.config.basicAuth.publicHeartbeat | bool | `true` | Set to true if you want the heartbeat endpoint to be publically accessible. This will have to be true if you have enabled basic auth.  |
+| broker.config.basicAuth.readUser | object | `{"existingSecret":"","existingSecretPasswordKey":"","existingSecretUsernameKey":"","password":"admin","username":"admin"}` | Pact Broker Basic Authentication Credentials For Read user |
+| broker.config.basicAuth.readUser.existingSecret | string | `""` | Name of an existing Kubernetes secret containing credentials to access the Pact Broker |
+| broker.config.basicAuth.readUser.existingSecretPasswordKey | string | `""` | The key to which holds the value of the password within the existingSecret |
+| broker.config.basicAuth.readUser.existingSecretUsernameKey | string | `""` | The key to which holds the value of the username within the existingSecret |
+| broker.config.basicAuth.readUser.password | string | `"admin"` | Password for read access to the Pact Broker |
+| broker.config.basicAuth.readUser.username | string | `"admin"` | Usermame for read access to the Pact Broker |
+| broker.config.basicAuth.writeUser | object | `{"existingSecret":"","existingSecretPasswordKey":"","existingSecretUsernameKey":"","password":"admin","username":"admin"}` | Pact Broker Basic Authentication Credentials For Write user |
+| broker.config.basicAuth.writeUser.existingSecret | string | `""` | Name of an existing Kubernetes secret containing credentials to access the Pact Broker |
+| broker.config.basicAuth.writeUser.existingSecretPasswordKey | string | `""` | The key to which holds the value of the password within the existingSecret |
+| broker.config.basicAuth.writeUser.existingSecretUsernameKey | string | `""` | The key to which holds the value of the username within the existingSecret |
+| broker.config.basicAuth.writeUser.password | string | `"admin"` | Password for write access to the Pact Broker |
+| broker.config.basicAuth.writeUser.username | string | `"admin"` | Usermame for write access to the Pact Broker |
+| broker.config.disable_ssl | bool | `false` | If set to true, SSL verification will be disabled for the HTTP requests made by the webhooks |
+| broker.containerPorts | object | `{"http":9292,"https":8443}` | Container port configuration  |
+| broker.containerPorts.http | int | `9292` | http port  |
+| broker.containerPorts.https | int | `8443` | http port  |
+| broker.containerSecurityContext | object | `{"enabled":true,"runAsNonRoot":true,"runAsUser":1001}` | Pact Broker containers' [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) |
+| broker.containerSecurityContext.enabled | bool | `true` | Enable Pact Broker containers' Security Context |
+| broker.containerSecurityContext.runAsNonRoot | bool | `true` | Set Pact Broker container's Security Context runAsNonRoot |
+| broker.containerSecurityContext.runAsUser | int | `1001` | Set Pact Broker container's Security Context runAsUser |
+| broker.labels | object | `{}` | Additional labels that can be added to the Broker deployment |
+| broker.livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":300,"periodSeconds":1,"successThreshold":1,"timeoutSeconds":5}` | Pact Broker [Liveness Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)  |
+| broker.livenessProbe.enabled | bool | `true` | Enable livenessProbe on Pact Broker containers |
+| broker.livenessProbe.failureThreshold | int | `3` | Failure threshold for livenessProbe |
+| broker.livenessProbe.initialDelaySeconds | int | `300` | Initial delay seconds for livenessProbe |
+| broker.livenessProbe.periodSeconds | int | `1` | Period seconds for livenessProbe |
+| broker.livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe |
+| broker.livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe |
+| broker.podSecurityContext | object | `{"enabled":true,"fsGroup":1001}` | Pact Broker pods' [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) |
+| broker.podSecurityContext.enabled | bool | `true` | Enable Pact Broker pods' Security Context |
+| broker.podSecurityContext.fsGroup | int | `1001` | Set Pact Broker pod's Security Context fsGroup |
+| broker.readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":30,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Pact Broker [Readiness Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes)  |
+| broker.readinessProbe.enabled | bool | `true` | Enable readinessProbe on Pact Broker containers |
+| broker.readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe |
+| broker.readinessProbe.initialDelaySeconds | int | `30` | Initial delay seconds for readinessProbe |
+| broker.readinessProbe.periodSeconds | int | `10` | Period seconds for readinessProbe |
+| broker.readinessProbe.successThreshold | int | `1` | Success threshold for readinessProbe |
+| broker.readinessProbe.timeoutSeconds | int | `1` | Timeout seconds for readinessProbe |
+| broker.replicaCount | int | `1` | Number of Pact Broker replicas to deploy |
+| broker.resources | object | `{"limits":{"cpu":"2500m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"512Mi"}}` | Pact Broker [resource requests and limits](https://kubernetes.io/docs/user-guide/compute-resources/) |
+| broker.resources.limits | object | `{"cpu":"2500m","memory":"1024Mi"}` | The resources limits for the Pact Broker containers |
+| broker.resources.requests | object | `{"cpu":"100m","memory":"512Mi"}` | The requested resources for the Pact Broker containers |
+| externalDatabase | object | `{"config":{"adapter":"","auth":{"existingSecret":"","existingSecretPasswordKey":"user-password","password":"","username":""},"databaseName":"","host":"","port":""},"enabled":false}` | External database configuration |
+| externalDatabase.config.adapter | string | `""` | Database engine to use. Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started) |
+| externalDatabase.config.auth | object | `{"existingSecret":"","existingSecretPasswordKey":"user-password","password":"","username":""}` | External database auth details that the Pact Broker will use to connect |
+| externalDatabase.config.auth.existingSecret | string | `""` | Name of an existing Kubernetes secret containing the database credentials |
+| externalDatabase.config.auth.existingSecretPasswordKey | string | `"user-password"` | The key to which the password will be stored under within existing secret. |
+| externalDatabase.config.auth.password | string | `""` | Password for the non-root username for the Pact Broker |
+| externalDatabase.config.auth.username | string | `""` | Non-root username for the Pact Broker |
+| externalDatabase.config.databaseName | string | `""` | External database name |
+| externalDatabase.config.host | string | `""` | Database host |
+| externalDatabase.config.port | string | `""` | Database port number |
+| externalDatabase.enabled | bool | `false` | Switch to enable or disable the externalDatabase connection |
+| image | object | `{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"docker.io","repository":"pactfoundation/pact-broker","tag":"2.100.0.1"}` | Pact Broker image information |
+| image.pullPolicy | string | `"IfNotPresent"` | Specify a imagePullPolicy Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent' more info [here](https://kubernetes.io/docs/user-guide/images/#pre-pulling-images)  |
+| image.pullSecrets | list | `[]` | Array of imagePullSecrets to allow pulling the Pact Broker image from private registries. PS: Secret's must exist in the namespace to which you deploy the Pact Broker. more info [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)   Example:   pullSecrets:    - mySecretName  |
+| image.registry | string | `"docker.io"` | Pact Broker image registry |
+| image.repository | string | `"pactfoundation/pact-broker"` | Pact Broker image repository |
+| image.tag | string | `"2.100.0.1"` | Pact Broker image tag (immutable tags are recommended) |
+| postgresql | object | `{"architecture":"standalone","auth":{"database":"bitnami_broker","existingSecret":"","password":"","secretKeys":{"adminPasswordKey":"admin-password","replicationPasswordKey":"replication-password","userPasswordKey":"user-password"},"username":"bn_broker"},"enabled":true}` | PostgreSQL [chart configuration](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml) |
+| postgresql.architecture | string | `"standalone"` | PostgreSQL architecture (`standalone` or `replication`) |
+| postgresql.auth | object | `{"database":"bitnami_broker","existingSecret":"","password":"","secretKeys":{"adminPasswordKey":"admin-password","replicationPasswordKey":"replication-password","userPasswordKey":"user-password"},"username":"bn_broker"}` | The authentication details of the Postgres database |
+| postgresql.auth.database | string | `"bitnami_broker"` | Name for a custom database to create |
+| postgresql.auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
+| postgresql.auth.password | string | `""` | Password for the custom user to create |
+| postgresql.auth.secretKeys | object | `{"adminPasswordKey":"admin-password","replicationPasswordKey":"replication-password","userPasswordKey":"user-password"}` | The secret keys Postgres will look for to retrieve the relevant password |
+| postgresql.auth.secretKeys.adminPasswordKey | string | `"admin-password"` | The key in which Postgres well look for, for the admin password, in the existing Secret |
+| postgresql.auth.secretKeys.replicationPasswordKey | string | `"replication-password"` | The key in which Postgres well look for, for the replication password, in the existing Secret |
+| postgresql.auth.secretKeys.userPasswordKey | string | `"user-password"` | The key in which Postgres well look for, for the user password, in the existing Secret |
+| postgresql.auth.username | string | `"bn_broker"` | Name for a custom user to create |
+| postgresql.enabled | bool | `true` | Switch to enable or disable the PostgreSQL helm chart |
+| service | object | `{"clusterIP":"","loadBalancerIP":"","nodePorts":{"http":"","https":""},"ports":{"http":80,"https":443},"type":"ClusterIP"}` | Service configuration |
+| service.clusterIP | string | `""` | Pact Broker service clusterIP |
+| service.loadBalancerIP | string | `""` | Pact Broker Service [loadBalancerIP](https://kubernetes.io/docs/user-guide/services/#type-loadbalancer) |
+| service.nodePorts | object | `{"http":"","https":""}` | Service [NodePort configuration](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) |
+| service.nodePorts.http | string | `""` | http nodePort |
+| service.nodePorts.https | string | `""` | https nodePort |
+| service.ports | object | `{"http":80,"https":443}` | Service port configuration |
+| service.ports.http | int | `80` | Pact service HTTP port |
+| service.ports.https | int | `443` | Pact service HTTPS port |
+| service.type | string | `"ClusterIP"` | Kubernetes service type  |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"labels":{},"name":"broker-sa"}` | Service Account Configuration |
+| serviceAccount.annotations | object | `{}` | Additional custom annotations for the ServiceAccount. |
+| serviceAccount.automountServiceAccountToken | bool | `true` | Auto-mount the service account token in the pod |
+| serviceAccount.create | bool | `true` | Enable the creation of a ServiceAccount for Pact Broker pods |
+| serviceAccount.labels | object | `{}` | Additional custom labels to the service ServiceAccount. |
+| serviceAccount.name | string | `"broker-sa"` | Name of the created ServiceAccount If not set and `serviceAccount.create` is true, a name is generated |
+
+## Configuration and Installation Details
+
+### Configuring Chart PostgreSQL
+
+With the Pact Broker Helm Chart, it bundles together the Pact Broker and a Bitnami PostgreSQL database - this can be enabled by switching `postgresql.enabled` to true (it is `true` by default). If switched on, the Helm Chart, on deployment, will automatically deploy a PostgreSQL instance and configure it with the credentials you specify. There are multiple ways of doing this that will be detailed below.
+
+#### Automatic Database Credential Creation
+This is the easiest of the configuration options. Here, the credentials for both the Admin and Database user will be automatically generated and put into a Kubernetes secret. This then will be automatically used by the Pact Broker. For this, ensure the following happens:
+  - Keep `postgresql.auth.existingSecret` & `postgresql.auth.password` empty.
+
+#### Specifying Password for PostgreSQL to Use
+Here, you can specify the password that you want PostgreSQL to use for it's Database User (The user that the Pact Broker will use to connect to the database). For this, ensure the following happens:
+  - Keep the `postgresql.auth.existingSecret` empty.
+  - Set the `postgresql.auth.password` to the value that you want the User password to be.
+  > **_NOTE:_** Be careful and mindful that the value you provide here is done in a secure way.
+
+#### Specifying Existing Secret for PostgreSQL to Use
+Here, you can specify an existing Kubernetes secret that you have created that contains the Password that you want PostgreSQL to use. The secret has to be in the same namespace as where you are deploying the Helm Chart. For this, ensure the following happens:
+  - Create the Kubernetes secret with the Password inside.
+  - Set `postgresql.auth.existingSecret` to the name of the Secret
+  - PostgreSQL by default will look for the relevant Password keys that are set by default here `postgresql.auth.secretKeys`. So make sure that the Keys in the Secret match the default `secretKeys` values. More information [here](https://artifacthub.io/packages/helm/bitnami/postgresql)
+  - For example, if you want PostgreSQL to use an existing Secret called `my-user-secret` that has the User password that you want to use inside it. Make sure that you create a Key inside that secret called `user-password` (this key can be found here `postgresql.auth.secretKeys.userPasswordKey`). i.e. `user-password=Password123`.
+
+### Configuring External Database
+If you want to use an external database with your Pact Broker, switch the `externalDatabase.enabled` flag to true and the `postgresql.enabled` to false.
+
+The configuring of the `externalDatabase.config.host`, `externalDatabase.config.port`, `externalDatabase.config.adapter` and `externalDatabase.config.databaseName` should be pretty straight forward. The credential configuration however has two methods of configuration.
+
+#### Specify Credentials via Values
+Configure the Pact Broker by using the username credential that you configure via the `externalDatabase.config.auth.username` value and the password via the `externalDatabase.config.auth.password` value.
+  > **_NOTE:_** Be careful and mindful that the values you provide here is done in a secure way.
+
+#### Specify Credentials via Secret
+Configure the Pact Broker to use an existing Secret to retrieve the user password as a means to connect to the database. Ensure that the Kubernetes Secret has the password in the `user-password` field and ensure that you have set `externalDatabase.config.auth.existingSecret` value to the name of the secret. To configure the username, you can use the `username` value.

--- a/charts/_readme_templates.gotmpl
+++ b/charts/_readme_templates.gotmpl
@@ -1,0 +1,52 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+
+## Configuration and Installation Details
+
+### Configuring Chart PostgreSQL
+
+With the Pact Broker Helm Chart, it bundles together the Pact Broker and a Bitnami PostgreSQL database - this can be enabled by switching `postgresql.enabled` to true (it is `true` by default). If switched on, the Helm Chart, on deployment, will automatically deploy a PostgreSQL instance and configure it with the credentials you specify. There are multiple ways of doing this that will be detailed below.
+
+#### Automatic Database Credential Creation
+This is the easiest of the configuration options. Here, the credentials for both the Admin and Database user will be automatically generated and put into a Kubernetes secret. This then will be automatically used by the Pact Broker. For this, ensure the following happens:
+  - Keep `postgresql.auth.existingSecret` & `postgresql.auth.password` empty.
+
+#### Specifying Password for PostgreSQL to Use
+Here, you can specify the password that you want PostgreSQL to use for it's Database User (The user that the Pact Broker will use to connect to the database). For this, ensure the following happens:
+  - Keep the `postgresql.auth.existingSecret` empty.
+  - Set the `postgresql.auth.password` to the value that you want the User password to be.
+  > **_NOTE:_** Be careful and mindful that the value you provide here is done in a secure way.
+
+#### Specifying Existing Secret for PostgreSQL to Use
+Here, you can specify an existing Kubernetes secret that you have created that contains the Password that you want PostgreSQL to use. The secret has to be in the same namespace as where you are deploying the Helm Chart. For this, ensure the following happens:
+  - Create the Kubernetes secret with the Password inside.
+  - Set `postgresql.auth.existingSecret` to the name of the Secret
+  - PostgreSQL by default will look for the relevant Password keys that are set by default here `postgresql.auth.secretKeys`. So make sure that the Keys in the Secret match the default `secretKeys` values. More information [here](https://artifacthub.io/packages/helm/bitnami/postgresql)
+  - For example, if you want PostgreSQL to use an existing Secret called `my-user-secret` that has the User password that you want to use inside it. Make sure that you create a Key inside that secret called `user-password` (this key can be found here `postgresql.auth.secretKeys.userPasswordKey`). i.e. `user-password=Password123`.
+
+### Configuring External Database
+If you want to use an external database with your Pact Broker, switch the `externalDatabase.enabled` flag to true and the `postgresql.enabled` to false.
+
+The configuring of the `externalDatabase.config.host`, `externalDatabase.config.port`, `externalDatabase.config.adapter` and `externalDatabase.config.databaseName` should be pretty straight forward. The credential configuration however has two methods of configuration.
+
+#### Specify Credentials via Values
+Configure the Pact Broker by using the username credential that you configure via the `externalDatabase.config.auth.username` value and the password via the `externalDatabase.config.auth.password` value.
+  > **_NOTE:_** Be careful and mindful that the values you provide here is done in a secure way.
+
+#### Specify Credentials via Secret
+Configure the Pact Broker to use an existing Secret to retrieve the user password as a means to connect to the database. Ensure that the Kubernetes Secret has the password in the `user-password` field and ensure that you have set `externalDatabase.config.auth.existingSecret` value to the name of the secret. To configure the username, you can use the `username` value.

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,120 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+This allows us to not have image: .Values.xxxx.ssss/.Values.xxx.xxx:.Values.ssss
+in every single template.
+*/}}
+{{- define "broker.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $imageName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag -}}
+{{- printf "%s/%s:%s" $registryName $imageName $tag -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "broker.postgresql.fullname" -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) -}}
+{{- end -}}
+
+{{/*
+Return the Database hostname
+*/}}
+{{- define "broker.databaseHost" -}}
+{{- if eq .Values.postgresql.architecture "replication" }}
+{{- ternary (include "broker.postgresql.fullname" .) .Values.externalDatabase.config.host .Values.postgresql.enabled -}}-primary
+{{- else -}}
+{{- ternary (include "broker.postgresql.fullname" .) .Values.externalDatabase.config.host .Values.postgresql.enabled -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Database port
+*/}}
+{{- define "broker.databasePort" -}}
+{{- ternary "5432" .Values.externalDatabase.config.port .Values.postgresql.enabled | quote -}}
+{{- end -}}
+
+{{/*
+Return the databaseAdapter configured
+*/}}
+{{- define "broker.databaseAdapter" -}}
+{{- ternary "postgres" .Values.externalDatabase.config.adapter .Values.postgresql.enabled | quote -}}
+{{- end -}}
+
+{{/*
+Return the database name
+*/}}
+{{- define "broker.databaseName" -}}
+{{- ternary .Values.postgresql.auth.database .Values.externalDatabase.config.databaseName .Values.postgresql.enabled | quote -}}
+{{- end -}}
+
+{{/*
+Return the Database username
+*/}}
+{{- define "broker.databaseUser" -}}
+{{- ternary .Values.postgresql.auth.username .Values.externalDatabase.config.auth.user .Values.postgresql.enabled | quote -}}
+{{- end -}}
+
+
+{{/*
+Return the Database Secret Name
+*/}}
+{{- define "broker.databaseSecretName" -}}
+{{- if .Values.postgresql.enabled }}
+    {{- if .Values.postgresql.auth.existingSecret }}
+        {{- tpl .Values.postgresql.auth.existingSecret $ -}}
+    {{- else -}}
+        {{- default (include "broker.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.externalDatabase.enabled }}
+        {{- .Values.externalDatabase.config.auth.existingSecret -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the databaseSecret key to retrieve credentials for database
+*/}}
+{{- define "broker.databaseSecretKey" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- if .Values.postgresql.auth.existingSecret -}}
+        {{- .Values.postgresql.auth.secretKeys.userPasswordKey  -}}
+    {{- else -}}
+        {{- print "password" -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.externalDatabase.enabled }}
+        {{- if .Values.externalDatabase.config.auth.existingSecret -}}
+            {{- .Values.externalDatabase.config.auth.existingSecretPasswordKey -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.broker.replicaCount }}
+  selector: 
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "chart.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "chart.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.broker.labels }}
+        {{ toYaml . | trim | indent 8 }}
+        {{- end }}
+      {{- if .Values.broker.annotations }}
+      annotations:
+        {{- with .Values.broker.annotations }}
+        {{ toYaml . | trim | indent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.broker.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.broker.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ template "chart.fullname" . }}
+          image: {{ template "broker.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.broker.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.broker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.broker.containerPorts.http }}
+              protocol: TCP
+            - name: https
+              containerPort: {{ .Values.broker.containerPorts.https }}
+              protocol: TCP
+          env:
+            - name: PACT_BROKER_PUBLIC_HEARTBEAT
+              value: {{ .Values.broker.config.basicAuth.publicHeartbeat | quote }}
+            - name: PACT_BROKER_PORT
+              value: {{ .Values.broker.containerPorts.http | quote }}
+            - name: PACT_BROKER_DISABLE_SSL_VERIFICATION
+              value: {{ .Values.broker.config.disable_ssl | quote }}
+            - name: PACT_BROKER_DATABASE_ADAPTER
+              value: {{ include "broker.databaseAdapter" . }}
+            - name: PACT_BROKER_DATABASE_HOST
+              value: {{ include "broker.databaseHost" . }}
+            - name: PACT_BROKER_DATABASE_PORT
+              value: {{ include "broker.databasePort" . }}
+            - name: PACT_BROKER_DATABASE_NAME
+              value: {{ include "broker.databaseName" . }}
+            - name: PACT_BROKER_DATABASE_USERNAME     
+              value: {{ include "broker.databaseUser" . }}
+            - name: PACT_BROKER_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "broker.databaseSecretName" . }}
+                  key: {{ include "broker.databaseSecretKey" . }}
+            - name: PACT_BROKER_BASIC_AUTH_USERNAME
+              {{- if .Values.broker.config.basicAuth.writeUser.username }}
+              value: {{ .Values.broker.config.basicAuth.writeUser.username }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.broker.config.basicAuth.writeUser.existingSecret }}
+                  key: {{ .Values.broker.config.basicAuth.writeUser.existingSecretUsernameKey }}
+              {{- end }}
+            - name: PACT_BROKER_BASIC_AUTH_PASSWORD
+              {{- if .Values.broker.config.basicAuth.writeUser.password }}
+              value: {{ .Values.broker.config.basicAuth.writeUser.password }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.broker.config.basicAuth.writeUser.existingSecret }}
+                  key: {{ .Values.broker.config.basicAuth.writeUser.existingSecretPasswordKey }}
+              {{- end }}
+            - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_USERNAME
+              {{- if .Values.broker.config.basicAuth.readUser.username }}
+              value: {{ .Values.broker.config.basicAuth.readUser.username }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.broker.config.basicAuth.readUser.existingSecret }}
+                  key: {{ .Values.broker.config.basicAuth.readUser.existingSecretUsernameKey }}
+              {{- end }}
+            - name: PACT_BROKER_BASIC_AUTH_READ_ONLY_PASSWORD
+              {{- if .Values.broker.config.basicAuth.readUser.password }}
+              value: {{ .Values.broker.config.basicAuth.readUser.password }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.broker.config.basicAuth.readUser.existingSecret }}
+                  key: {{ .Values.broker.config.basicAuth.readUser.existingSecretPasswordKey }}
+              {{- end }}
+            - name: PACT_BROKER_ALLOW_PUBLIC_READ
+              value: {{ .Values.broker.config.basicAuth.allowPublicRead | quote }}
+            - name: PACT_BROKER_ENABLE_PUBLIC_BADGE_ACCESS
+              value: {{ .Values.broker.config.basicAuth.enablePublicBadgeAccess | quote }}
+          resources:
+            {{- toYaml .Values.broker.resources | nindent 12 }}
+          {{- if .Values.broker.livenessProbe.enabled }}
+          livenessProbe: {{- omit .Values.broker.livenessProbe "enabled" | toYaml | nindent 12 }}
+            httpGet:
+              path: /diagnostic/status/heartbeat
+              port: http
+          {{- end }}
+          {{- if .Values.broker.readinessProbe.enabled }}
+          readinessProbe: {{- omit .Values.broker.readinessProbe "enabled" | toYaml | nindent 12 }}
+            httpGet:
+              path: /diagnostic/status/heartbeat
+              port: http
+          {{- end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    name: {{ include "chart.fullname" . }}
+    app.kubernetes.io/name: {{ include "chart.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ coalesce .Values.service.ports.http .Values.service.port }}
+      protocol: TCP
+      targetPort: http
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http))) }}
+      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    - name: https
+      port: {{ coalesce .Values.service.ports.https .Values.service.httpsPort }}
+      protocol: TCP
+      targetPort: https
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https))) }}
+      nodePort: {{ .Values.service.nodePorts.https }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "chart.name" . }}

--- a/charts/templates/serviceaccount.yaml
+++ b/charts/templates/serviceaccount.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: pact-broker
+      {{- with .Values.serviceAccount.labels }}
+      {{ toYaml . | trim | indent 8 }}
+      {{- end }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- with .Values.serviceAccount.annotations }}
+    {{ toYaml . | trim | indent 8 }}
+    {{- end }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,306 @@
+# -- Pact Broker image information
+image:
+
+  # -- Pact Broker image registry
+  registry: docker.io
+
+  # -- Pact Broker image repository
+  repository: pactfoundation/pact-broker
+
+  # -- Pact Broker image tag (immutable tags are recommended)
+  tag: 2.100.0.1
+
+  # -- Specify a imagePullPolicy
+  # Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  # more info [here](https://kubernetes.io/docs/user-guide/images/#pre-pulling-images)
+  #
+  pullPolicy: IfNotPresent
+
+  # -- Array of imagePullSecrets to allow pulling the Pact Broker image from private registries.
+  # PS: Secret's must exist in the namespace to which you deploy the Pact Broker.
+  # more info [here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) 
+  #
+  # Example:
+  #   pullSecrets:
+  #    - mySecretName
+  #
+  pullSecrets: []
+
+# -- Broker configuration
+#
+broker:
+
+  # -- Additional labels that can be added to the Broker deployment
+  labels: {}
+
+  # -- Additional annotations that can be added to the Broker deployment
+  annotations: {}
+
+  # -- Number of Pact Broker replicas to deploy
+  replicaCount: 1
+
+  # -- Container port configuration 
+  containerPorts:
+
+    # -- http port 
+    http: 9292
+
+    # -- http port 
+    https: 8443
+
+  # -- Pact Broker pods' [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  podSecurityContext:
+
+    # -- Enable Pact Broker pods' Security Context
+    enabled: true
+
+    # -- Set Pact Broker pod's Security Context fsGroup
+    fsGroup: 1001
+
+  # -- Pact Broker containers' [Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+  containerSecurityContext:
+
+    # -- Enable Pact Broker containers' Security Context
+    enabled: true
+
+    # -- Set Pact Broker container's Security Context runAsUser
+    runAsUser: 1001
+
+    # -- Set Pact Broker container's Security Context runAsNonRoot
+    runAsNonRoot: true
+
+  # -- Pact Broker Config
+  config:
+
+    # -- If set to true, SSL verification will be disabled for the HTTP requests made by the webhooks
+    disable_ssl: false
+
+    # -- Pact Broker Basic Authentication
+    basicAuth:
+
+      # -- Set to true if you want the heartbeat endpoint to be publically accessible.
+      # This will have to be true if you have enabled basic auth. 
+      publicHeartbeat: true
+
+      # -- Pact Broker Basic Authentication Credentials For Write user
+      writeUser:
+
+        # -- Usermame for write access to the Pact Broker
+        username: "admin"
+
+        # -- Password for write access to the Pact Broker
+        password: "admin"
+
+        # -- Name of an existing Kubernetes secret containing credentials to access the Pact Broker
+        existingSecret: ""
+
+        # -- The key to which holds the value of the username within the existingSecret
+        existingSecretUsernameKey: ""
+
+        # -- The key to which holds the value of the password within the existingSecret
+        existingSecretPasswordKey: ""
+
+      # -- Pact Broker Basic Authentication Credentials For Read user
+      readUser:
+
+        # -- Usermame for read access to the Pact Broker
+        username: "admin"
+
+        # -- Password for read access to the Pact Broker
+        password: "admin"
+
+        # -- Name of an existing Kubernetes secret containing credentials to access the Pact Broker
+        existingSecret: ""
+
+        # -- The key to which holds the value of the username within the existingSecret
+        existingSecretUsernameKey: ""
+
+        # -- The key to which holds the value of the password within the existingSecret
+        existingSecretPasswordKey: ""
+
+      # -- Set to true if you want public read access, but still require credentials for writing.
+      #
+      allowPublicRead: false
+
+
+      # -- Set this to true to allow status badges to be embedded in README files without requiring a hardcoded password.
+      enablePublicBadgeAccess: false
+  
+  # -- Pact Broker [resource requests and limits](https://kubernetes.io/docs/user-guide/compute-resources/)
+  resources:
+
+    # -- The resources limits for the Pact Broker containers
+    limits:
+      memory: 1024Mi
+      cpu: 2500m
+    
+    # -- The requested resources for the Pact Broker containers
+    requests:
+      memory: 512Mi
+      cpu: 100m
+
+  # -- Pact Broker [Liveness Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) 
+  livenessProbe:
+
+    # -- Enable livenessProbe on Pact Broker containers
+    enabled: true
+
+    # -- Initial delay seconds for livenessProbe
+    initialDelaySeconds: 300
+
+    # -- Period seconds for livenessProbe
+    periodSeconds: 1
+
+    # -- Timeout seconds for livenessProbe
+    timeoutSeconds: 5
+
+    # -- Failure threshold for livenessProbe
+    failureThreshold: 3
+
+    # -- Success threshold for livenessProbe
+    successThreshold: 1
+
+  # -- Pact Broker [Readiness Probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) 
+  readinessProbe:
+
+    # -- Enable readinessProbe on Pact Broker containers
+    enabled: true
+
+    # -- Initial delay seconds for readinessProbe
+    initialDelaySeconds: 30
+
+    # -- Period seconds for readinessProbe
+    periodSeconds: 10
+
+    # -- Timeout seconds for readinessProbe
+    timeoutSeconds: 1
+
+    # -- Failure threshold for readinessProbe
+    failureThreshold: 3
+
+    # -- Success threshold for readinessProbe
+    successThreshold: 1
+
+# -- Service configuration
+service:
+
+  # -- Kubernetes service type
+  #
+  type: "ClusterIP"
+
+  # -- Service port configuration
+  ports:
+
+    # -- Pact service HTTP port
+    http: 80
+
+    # -- Pact service HTTPS port
+    https: 443
+
+  # -- Service [NodePort configuration](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
+  nodePorts:
+
+    # -- http nodePort
+    http: ""
+
+    # -- https nodePort
+    https: ""
+
+  # -- Pact Broker service clusterIP
+  clusterIP: ""
+
+  # -- Pact Broker Service [loadBalancerIP](https://kubernetes.io/docs/user-guide/services/#type-loadbalancer)
+  loadBalancerIP: ""
+
+# -- PostgreSQL [chart configuration](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml)
+postgresql:
+
+  # -- Switch to enable or disable the PostgreSQL helm chart
+  enabled: true
+
+  # -- The authentication details of the Postgres database
+  auth:
+
+    # -- Name for a custom user to create
+    username: bn_broker
+
+    # -- Password for the custom user to create
+    password: ""
+
+    # -- Name for a custom database to create
+    database: bitnami_broker
+    
+    # -- Name of existing secret to use for PostgreSQL credentials
+    existingSecret: ""
+
+    # -- The secret keys Postgres will look for to retrieve the relevant password
+    secretKeys:
+
+      # -- The key in which Postgres well look for, for the admin password, in the existing Secret
+      adminPasswordKey: admin-password
+
+      # -- The key in which Postgres well look for, for the user password, in the existing Secret
+      userPasswordKey: user-password
+
+      # -- The key in which Postgres well look for, for the replication password, in the existing Secret
+      replicationPasswordKey: replication-password
+  
+  # -- PostgreSQL architecture (`standalone` or `replication`)
+  architecture: standalone
+
+# -- External database configuration
+externalDatabase:
+
+  # -- Switch to enable or disable the externalDatabase connection
+  enabled: false
+
+  # -- 
+  config:
+
+    # -- Database host
+    host: ""
+
+    # -- Database port number
+    port: ""
+
+    # -- Database engine to use.
+    # Only allowed values are `postgres` or `sqlite`. More info [here](https://docs.pact.io/pact_broker/docker_images/pactfoundation#getting-started)
+    adapter: "" 
+
+    # -- External database name
+    databaseName: ""
+
+    # -- External database auth details that the Pact Broker will use to connect
+    auth:
+
+      # -- Non-root username for the Pact Broker
+      username: ""
+
+      # -- Password for the non-root username for the Pact Broker
+      password: ""
+
+      # -- Name of an existing Kubernetes secret containing the database credentials
+      existingSecret: ""
+
+      # -- The key to which the password will be stored under within existing secret.
+      existingSecretPasswordKey: "user-password"
+
+# -- Service Account Configuration
+serviceAccount:
+
+
+  # -- Enable the creation of a ServiceAccount for Pact Broker pods
+  create: true
+
+  # -- Name of the created ServiceAccount
+  # If not set and `serviceAccount.create` is true, a name is generated
+  name: broker-sa
+
+  # -- Additional custom labels to the service ServiceAccount.
+  labels: {}
+
+  # -- Additional custom annotations for the ServiceAccount.
+  annotations: {}
+
+  # -- Auto-mount the service account token in the pod
+  automountServiceAccountToken: true


### PR DESCRIPTION
Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>

Adds the Helm Chart for the Pact Broker. This makes it easier to install onto Kubernetes, avoiding users having to have their own custom Helm charts which will most likely differ. Addresses [#564](https://github.com/pact-foundation/pact_broker/issues/564)

What it includes:
- Ability to deploy Pact Broker onto Kubernetes via Helm.
- By Default it will setup a PostgreSQL Database (Bitnami) and configure all authentication and user credentials for Pact to use. The chart also offers the user to set their own passwords, and use existing secrets. With the addition of using an external database. All of this is documented in the README.md
- Excludes an Ingress object as currently we don't use them as we are using Istio Gateway. I was debating adding it but I wouldn't be able to test it. It should be very trivial for someone to add if they wanted as it's just the extra file.
- The only other thing to do would be to add all of the environment variable options to the Chart so that it can be configured. I've done a lot of them already, but again, this should be a trivial task if someone wanted to add a config parameter that it doesn't currently have.

As stated on the issue ticket, it's probably best to have this in its own repo as it will have its own pipeline that automatically creates the release when a new version of the Chart is made.