### PR TITLE
Issue #93: Upgrade Bundler to version 2.2.33 to fix security issues.

### DIFF
--- a/Dockerfile-bundle-base
+++ b/Dockerfile-bundle-base
@@ -10,6 +10,6 @@ RUN set -ex && \
   chmod g+w $HOME && \
   apk add --update --no-cache make gcc libc-dev mariadb-dev postgresql-dev sqlite-dev
 
-RUN gem install bundler -v 2.1.4
+RUN gem install bundler -v 2.2.33
 COPY pact_broker/Gemfile pact_broker/Gemfile.lock $HOME/
 RUN bundle install --no-cache

--- a/Dockerfile-package-base
+++ b/Dockerfile-package-base
@@ -5,7 +5,7 @@ ENV HOME=/app
 WORKDIR $HOME
 
 RUN apk add --update --no-cache git
-RUN gem install bundler -v 2.1.4
+RUN gem install bundler -v 2.2.33
 
 COPY Rakefile $HOME/
 COPY Gemfile Gemfile.lock $HOME/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,4 +207,4 @@ DEPENDENCIES
   webrick (~> 1.6)
 
 BUNDLED WITH
-   2.1.4
+   2.2.33

--- a/pact_broker/Gemfile.lock
+++ b/pact_broker/Gemfile.lock
@@ -168,4 +168,4 @@ DEPENDENCIES
   webrick (~> 1.6)
 
 BUNDLED WITH
-   2.1.4
+   2.2.33


### PR DESCRIPTION
Fix security issues described in [issue #93](https://github.com/pact-foundation/pact-broker-docker/issues/93).