### PR TITLE
chore(deps): upgrade SuperCronic to ver 0.2.2 to fix Multiple CVE:s with severity level High due to use of SuperCronic 0.2.1 (that uses Go-lang version 1.18.3). #103

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ruby:2.7.7-alpine3.16
 
 ARG SUPERCRONIC_PLATFORM=amd64
-ARG SUPERCRONIC_SHA1SUM=d7f4c0886eb85249ad05ed592902fa6865bb9d70
+ARG SUPERCRONIC_SHA1SUM=2319da694833c7a147976b8e5f337cd83397d6be
 
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.1/supercronic-linux-${SUPERCRONIC_PLATFORM} \
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.2/supercronic-linux-${SUPERCRONIC_PLATFORM} \
     SUPERCRONIC=supercronic-linux-${SUPERCRONIC_PLATFORM}
 
 RUN wget "$SUPERCRONIC_URL" \


### PR DESCRIPTION
fix #103

SuperCronic has now upgraded the underlaying Go-lang version.