### PR TITLE
chore(dev-ex): remove docker login step from test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,6 @@ jobs:
       - run: "bundle install"
       - run: "bundle exec rake"
 
-      - name: Login to Docker Hub
-        run: script/release-workflow/docker-login.sh
-        env:
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-
       - name: Build Docker image
         run: docker buildx build --platform=${DOCKER_TARGET_PLATFORM} -t pactfoundation/pact-broker:latest .
 


### PR DESCRIPTION
PR builds from contributors fail because they don't have access to secrets to login to the docker repository.

Not sure why this step is needed, as we test from the image built in the CI run, and don't push it as part of this job.

Maybe its due to docker licensing restrictions? 🤷🏾‍♂️ 

It also stops dependency update builds from running the test step, which causes more headache for maintainers, example PR actions run 

https://github.com/pact-foundation/pact-broker-docker/actions/runs/4675302277/jobs/8280283767#step:6:9