### PR TITLE
ci(dev-ex): run trivy audit as cron job so no release surpises

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,6 +2,7 @@ name: Audit
 
 on:
   workflow_dispatch:
+  push:
   schedule:
     - cron: 0 0 * * 4 # Midnight Wednesday
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,21 @@
+name: Audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * 4 # Midnight Wednesday
+
+env:
+  DOCKER_TARGET_PLATFORM: "linux/amd64"
+
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+      - run: "bundle install"
+      - name: Build Docker image
+        run: docker buildx build --platform=${DOCKER_TARGET_PLATFORM} -t pactfoundation/pact-broker:latest .
+      - name: Audit image
+        run: script/release-workflow/audit.sh

--- a/script/release-workflow/audit.sh
+++ b/script/release-workflow/audit.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -euo >/dev/null
+
+script_dir=$(cd "$(dirname $0)" && pwd)
+
+. ${script_dir}/set-env-vars.sh
+
+${script_dir}/docker-build.sh
+${script_dir}/docker-scan.sh


### PR DESCRIPTION
Run the trivy audit as a cron job, so that we get alerted to issues, rather than only being run at release time

Current error when running trivy against a built image 

https://github.com/YOU54F/pact-broker-docker/actions/runs/4735726395/jobs/8406325952

```
aquasecurity/trivy info checking GitHub for latest tag
aquasecurity/trivy info found version: 0.40.0 for v0.40.0/Linux/64bit
aquasecurity/trivy info installed /usr/local/bin/trivy
2023-04-18T18:28:08.143Z	INFO	Need to update DB
2023-04-18T18:28:08.143Z	INFO	DB Repository: ghcr.io/aquasecurity/trivy-db
2023-04-18T18:28:08.143Z	INFO	Downloading DB...
2023-04-18T18:28:10.786Z	INFO	Vulnerability scanning is enabled
2023-04-18T18:28:10.786Z	INFO	Secret scanning is enabled
2023-04-18T18:28:10.786Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-04-18T18:28:10.786Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.40/docs/secret/scanning/#recommendation for faster secret detection
2023-04-18T18:28:14.782Z	INFO	Detected OS: alpine
2023-04-18T18:28:14.783Z	INFO	Detecting Alpine vulnerabilities...
2023-04-18T18:28:14.803Z	INFO	Number of language-specific files: 1
2023-04-18T18:28:14.809Z	INFO	Detecting bundler vulnerabilities...

d87bbcb8b521 (alpine 3.16.5)
============================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


pact_broker/Gemfile.lock (bundler)
==================================
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌──────────┬─────────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│ Library  │    Vulnerability    │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├──────────┼─────────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ nokogiri │ GHSA-pxvg-2qj5-37jq │ MEDIUM   │ 1.14.2            │ >= 1.14.3     │ Update packaged libxml2 to v2.10.4 to resolve multiple CVEs │
│          │                     │          │                   │               │ https://github.com/advisories/GHSA-pxvg-2qj5-37jq           │
```