### PR TITLE
ci(audit): remove audit step for armv7

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        DOCKER_TARGET_PLATFORM: [linux/arm, linux/arm64, linux/amd64]
+        DOCKER_TARGET_PLATFORM: [linux/arm64, linux/amd64]
     runs-on: ubuntu-latest
     env:
       DOCKER_TARGET_PLATFORM: ${{ matrix.DOCKER_TARGET_PLATFORM }}


### PR DESCRIPTION
due to missing binaries 

https://github.com/aquasecurity/trivy/discussions/4972