### PR TITLE
chore(deps): ruby:3.2.2-alpine3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.1-alpine3.17 as base
+FROM ruby:3.2.2-alpine3.18 as base
 
 # 1. Install target specfic dependencies
 # - gcompat required for arm/arm64 (otherwise nokogiri breaks when viewing network graph)

--- a/Dockerfile-bundle-base
+++ b/Dockerfile-bundle-base
@@ -1,4 +1,4 @@
-FROM ruby:2.7.8-alpine3.16
+FROM ruby:3.2.2-alpine3.18
 
 # Installation path
 ENV HOME=/pact_broker
@@ -10,6 +10,6 @@ RUN set -ex && \
   chmod g+w $HOME && \
   apk add --update --no-cache make gcc libc-dev mariadb-dev postgresql-dev sqlite-dev
 
-RUN gem install bundler -v 2.4.7
+RUN gem install bundler -v 2.4.12
 COPY pact_broker/Gemfile pact_broker/Gemfile.lock $HOME/
 RUN bundle install --no-cache

--- a/Dockerfile-package-base
+++ b/Dockerfile-package-base
@@ -1,11 +1,11 @@
-FROM ruby:2.7.8-alpine3.16
+FROM ruby:3.2.2-alpine3.18
 
 # Installation path
 ENV HOME=/app
 WORKDIR $HOME
 
 RUN apk add --update --no-cache git
-RUN gem install bundler -v 2.4.7
+RUN gem install bundler -v 2.4.12
 
 COPY Rakefile $HOME/
 COPY Gemfile Gemfile.lock $HOME/


### PR DESCRIPTION
Release notes for Ruby 3.2.2

- https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/

Release notes for Alpine 3.18

- https://www.alpinelinux.org/posts/Alpine-3.18.0-released.html

_notes:_ - I assume we may wish to regenerate the lock file, run from Alpine 3.18, and update Bundler to either the same version as included in the image, or the latest