### PR TITLE
update superCronic to 0.2.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ FROM ruby:3.2.1-alpine3.17 as base
 #   - https://github.com/sparklemotion/nokogiri/issues/2414
 # 2. Supercronic - setup sha1sum for each supported architecture
 FROM base AS base-amd64
-ENV SUPERCRONIC_SHA1SUM=6817299e04457e5d6ec4809c72ee13a43e95ba41
+ENV SUPERCRONIC_SHA1SUM=7dadd4ac827e7bd60b386414dfefc898ae5b6c63
 FROM base AS base-arm64
-ENV SUPERCRONIC_SHA1SUM=fce407a3d7d144120e97cfc0420f16a18f4637d9
+ENV SUPERCRONIC_SHA1SUM=ec114784804d76b562a473ebe8ed972383f960e2
 RUN apk add --update --no-cache gcompat
 FROM base AS base-arm
-ENV SUPERCRONIC_SHA1SUM=fad9380ed30b9eae61a5b1089f93bd7ee8eb1a9c
+ENV SUPERCRONIC_SHA1SUM=6b04fe278b364d0b35b066250a129cb44c04b990
 RUN apk add --update --no-cache gcompat
 
 # Supercronic - use base-$TARGETARCH to select correct base image SUPERCRONIC_SHA1SUM
@@ -19,7 +19,7 @@ FROM base-$TARGETARCH AS pb-dev
 
 # Install Supercronic
 ARG TARGETARCH
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.24/supercronic-linux-${TARGETARCH} \
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.2.27/supercronic-linux-${TARGETARCH} \
     SUPERCRONIC=supercronic-linux-${TARGETARCH}
 RUN wget "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \


### PR DESCRIPTION
Update SuperCronic to 0.2.27 to ensure updated version of GO.
This should get rid of vulnerabilities in older GO versions.
Updated the version and the SHA's according to this page 
https://github.com/aptible/supercronic/releases/tag/v0.2.27

`CMD ["config.ru"]` on line 77 is copied from the chore/deps/supercronic/v0.2.26