### PR TITLE
use multi image to support apple silicon out of the box

### DIFF
--- a/docker-compose-clean-cron.yml
+++ b/docker-compose-clean-cron.yml
@@ -14,7 +14,7 @@ services:
       - ${PWD}/docker/pg-dump.sql:/tmp/pg-dump.sql
 
   pact-broker:
-    image: "pactfoundation/pact-broker:2.110.0-pactbroker2.107.1"
+    image: "pactfoundation/pact-broker:2.110.0-pactbroker2.107.1-multi"
     ports:
       - "9393:9393"
     depends_on:

--- a/docker-compose-clean.yml
+++ b/docker-compose-clean.yml
@@ -14,7 +14,7 @@ services:
       - ${PWD}/docker/pg-dump.sql:/tmp/pg-dump.sql
 
   pact-broker:
-    image: "pactfoundation/pact-broker:2.110.0-pactbroker2.107.1"
+    image: "pactfoundation/pact-broker:2.110.0-pactbroker2.107.1-multi"
     ports:
       - "9393:9393"
     depends_on:

--- a/docker-compose-heroku.yml
+++ b/docker-compose-heroku.yml
@@ -17,7 +17,7 @@ services:
       POSTGRES_DB: postgres
 
   pact-broker:
-    image: "pactfoundation/pact-broker:2.110.0-pactbroker2.107.1"
+    image: "pactfoundation/pact-broker:2.110.0-pactbroker2.107.1-multi"
     ports:
       - "9393:9393"
     depends_on:

--- a/docker-compose-test-different-env-var-names.yml
+++ b/docker-compose-test-different-env-var-names.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_DB: postgres
 
   pact-broker:
-    image: "pactfoundation/pact-broker:latest"
+    image: "pactfoundation/pact-broker:latest-multi"
     depends_on:
       - postgres
     environment:

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_DB: postgres
 
   pact-broker:
-    image: "pactfoundation/pact-broker:latest"
+    image: "pactfoundation/pact-broker:latest-multi"
     depends_on:
       - postgres
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       POSTGRES_DB: postgres
 
   pact-broker:
-    image: "pactfoundation/pact-broker:2.110.0-pactbroker2.107.1"
+    image: "pactfoundation/pact-broker:2.110.0-pactbroker2.107.1-multi"
     ports:
       - "9292:9292"
     depends_on:


### PR DESCRIPTION
I think it makes sense to use `multi` image instead since otherwise on new macs without `DOCKER_DEFAULT_PLATFORM=linux/amd64` you would get an error:
```
✦ ➜ docker compose up -d
[+] Running 0/3
 ⠦ postgres Pulling                                                                                                                                                                                                                                                                                                        1.7s
 ⠦ pact-broker Pulling                                                                                                                                                                                                                                                                                                     1.7s
 ⠦ nginx Pulling                                                                                                                                                                                                                                                                                                           1.7s
no matching manifest for linux/arm64 in the manifest list entries
```