### PR TITLE
feat: Docker/publish to ghcr

### DIFF
--- a/.github/workflows/release_image.yml
+++ b/.github/workflows/release_image.yml
@@ -49,6 +49,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
       - run: "bundle install"
 
+      - name: Log into ghcr registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Release image
         run: script/release-workflow/run.sh
         env:

--- a/README.md
+++ b/README.md
@@ -35,26 +35,14 @@ If you want to run the container as a standalone instance, then the `dius/pact-b
 
 ## Platforms
 
-### Single platform images
-
-By default, vanilla tags, are built only for `amd64`
-
-- `--platform=linux/amd64`
-
-  ```sh
-  docker run --rm -it --entrypoint /bin/sh pactfoundation/pact-broker:latest -c 'uname -sm'
-  ```
-
-### Multi-manifest image
-
-Multi-platform images are available, by appending `-multi` to any release tag
+Multi-platform images are available
 
 - `--platform=linux/amd64`
 - `--platform=linux/arm/v7`
 - `--platform=linux/arm64`
 
   ```sh
-  docker run --rm -it --entrypoint /bin/sh pactfoundation/pact-broker:latest-multi -c 'uname -sm'
+  docker run --rm -it --entrypoint /bin/sh pactfoundation/pact-broker:latest -c 'uname -sm'
   ```
 
 ## Prerequisites

--- a/script/release-workflow/docker-push.sh
+++ b/script/release-workflow/docker-push.sh
@@ -2,29 +2,21 @@
 
 set -euo >/dev/null
 
-## Publish a multi arch build with -multi added to the tag
-## ($TAG||$MAJOR_TAG||$LATEST)-multi
-push_multi() {
+## Publish a multi arch build
+## ($TAG||$MAJOR_TAG||$LATEST)
+push() {
   ## These will use cached builds, so wont build every time.
   docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
-    --output=type=image,push=true \
-    -t ${DOCKER_IMAGE_ORG_AND_NAME}:$1-multi .
-}
-push() {
-  docker buildx build --platform=linux/amd64 \
     --output=type=image,push=true \
     -t ${DOCKER_IMAGE_ORG_AND_NAME}:$1 .
 }
 
 if [ -n "${MAJOR_TAG:-}" ]; then
   push ${MAJOR_TAG}
-  push_multi ${MAJOR_TAG}
 fi
 
 push ${TAG}
-push_multi ${TAG}
 
 if [ "${PUSH_TO_LATEST}" != "false" ]; then
   push latest
-  push_multi latest
 fi

--- a/script/release-workflow/docker-push.sh
+++ b/script/release-workflow/docker-push.sh
@@ -10,13 +10,21 @@ push() {
     --output=type=image,push=true \
     -t ${DOCKER_IMAGE_ORG_AND_NAME}:$1 .
 }
+push_ghcr() {
+  docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
+  --output=type=image,push=true \
+  -t ghcr.io/${DOCKER_IMAGE_ORG_AND_NAME}:$1 
+}
 
 if [ -n "${MAJOR_TAG:-}" ]; then
   push ${MAJOR_TAG}
+  push_ghcr ${MAJOR_TAG}
 fi
 
 push ${TAG}
+push_ghcr ${TAG}
 
 if [ "${PUSH_TO_LATEST}" != "false" ]; then
   push latest
+  push_ghcr latest
 fi


### PR DESCRIPTION
Publish images to ghcr.io as well as docker.io

- [main tracking ticket](https://github.com/pact-foundation/devrel/issues/29)
- [pact-ruby-cli PR](https://github.com/pact-foundation/pact-ruby-cli/pull/127)

Note. includes #171 so we aren't publishing the `-multi` suffixed images to ghcr 