### PR TITLE
fix: ghcr images need to publish to pact-foundation / dockerhub images to pactfoundation

### DIFF
--- a/script/release-workflow/docker-push.sh
+++ b/script/release-workflow/docker-push.sh
@@ -13,7 +13,7 @@ push() {
 push_ghcr() {
   docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
   --output=type=image,push=true \
-  -t ghcr.io/${DOCKER_IMAGE_ORG_AND_NAME/pactfoundation/pact-foundation}:$1 .
+  -t ghcr.io/$(echo $DOCKER_IMAGE_ORG_AND_NAME | sed 's/pactfoundation/pact-foundation/g'):$1 .
 }
 
 if [ -n "${MAJOR_TAG:-}" ]; then

--- a/script/release-workflow/docker-push.sh
+++ b/script/release-workflow/docker-push.sh
@@ -13,7 +13,7 @@ push() {
 push_ghcr() {
   docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
   --output=type=image,push=true \
-  -t ghcr.io/${DOCKER_IMAGE_ORG_AND_NAME}:$1 .
+  -t ghcr.io/${DOCKER_IMAGE_ORG_AND_NAME/pactfoundation/pact-foundation}:$1 .
 }
 
 if [ -n "${MAJOR_TAG:-}" ]; then


### PR DESCRIPTION


GitHub container registries must contain a matching NAMESPACE to the GitHub user or org.

This worked on my personal fork, as my GH and Docker username are the same, however pact-foundation uses a hyphen-less NAMESPACE when publishing to docker.io

https://hub.docker.com/u/pactfoundation

We therefore need to set the org name to pact-foundation when publishing to ghcr.