### PR TITLE
Revert "feat: bind to IPv6 'any' as well as IPv4 'any'"

### DIFF
--- a/pact_broker/config/puma.rb
+++ b/pact_broker/config/puma.rb
@@ -1,7 +1,6 @@
 require_relative "../docker_configuration"
 
-bind "tcp://0.0.0.0:#{PactBroker.docker_configuration.port}"
-bind "tcp://[::]:#{PactBroker.docker_configuration.port}"
+port PactBroker.docker_configuration.port
 
 if PactBroker.docker_configuration.puma_persistent_timeout
   persistent_timeout PactBroker.docker_configuration.puma_persistent_timeout

--- a/script/test.sh
+++ b/script/test.sh
@@ -5,7 +5,7 @@ set -e
 docker_compose_files=$(find . -name "docker-compose-test*.yml")
 
 for file in $docker_compose_files; do
-  cat $file | sed -e "s~image: pactfoundation/pact-broker:.*~image: pactfoundation/pact-broker:${TAG}~g" > dc-tmp
+  cat $file | sed -e "s/pactfoundation\/pact-broker:latest.*/pactfoundation\/pact-broker:${TAG}\"/g" > dc-tmp
   mv dc-tmp $file
 done
 


### PR DESCRIPTION
Reverts pact-foundation/pact-broker-docker#170

Re: failing build

https://github.com/pact-foundation/pact-python/pull/578

Relates to comments noted during thisPR

https://github.com/pact-foundation/pact-broker-docker/pull/173#issue-2154393809

It seems we might need to dig into this a bit further to understand why we are seeing intermittent failures before rolling this out, as they are cropping up in consuming projects