### PR TITLE
feat: Add OCI image annotations

### DIFF
--- a/script/release-workflow/docker-push.sh
+++ b/script/release-workflow/docker-push.sh
@@ -7,6 +7,8 @@ set -euo >/dev/null
 push() {
   ## These will use cached builds, so wont build every time.
   docker buildx build --platform=linux/amd64,linux/arm64,linux/arm \
+    --annotation "org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+    --annotation "org.opencontainers.image.revision=$GITHUB_SHA" \
     --output=type=image,push=true \
     -t ${DOCKER_IMAGE_ORG_AND_NAME}:$1 .
 }


### PR DESCRIPTION
These annotations are useful for tools (such as Renovate and Snyk) to use as well as for manual use by individuals.

For example, [Snyk uses them in its UI](https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/) and [Renovate uses them to find release notes](https://github.com/renovatebot/renovate/blob/34.115.1/lib/modules/datasource/docker/readme.md).

See: https://github.com/opencontainers/image-spec/blob/v1.1.0/annotations.md#pre-defined-annotation-keys