### PR TITLE
fix(ci): docker-compose possibly causing issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ If you are running more than one Pact Broker Docker container at a time for the 
 You can see a working example in the [docker-compose-clean.yml](./docker-compose-clean.yml) file. To run the example locally, run:
 
 ```
-docker-compose -f docker-compose-clean.yml up pact-broker
+docker compose -f docker-compose-clean.yml up pact-broker
 
 # in another console
-docker-compose -f docker-compose-clean.yml up clean
+docker compose -f docker-compose-clean.yml up clean
 ```
 
 ### Known issues with the data clean up task
@@ -173,8 +173,8 @@ For a quick start with the Pact Broker and Postgres, we have an example
 [Docker Compose][docker-compose] setup you can use:
 
 1. Modify the `docker-compose.yml` file as required.
-2. Run `docker-compose build` to build the pact_broker container locally.
-3. Run `docker-compose up` to get a running Pact Broker and a clean Postgres database.
+2. Run `docker compose build` to build the pact_broker container locally.
+3. Run `docker compose up` to get a running Pact Broker and a clean Postgres database.
 
 Now you can access your local broker:
 

--- a/example-k8s-deployment/infrastructure/deploy_cfn.sh
+++ b/example-k8s-deployment/infrastructure/deploy_cfn.sh
@@ -3,7 +3,7 @@
 stack=$1
 env=$2
 
-docker-compose run --rm stackup-"$env" pact-broker-"$stack" up \
+docker compose run --rm stackup-"$env" pact-broker-"$stack" up \
   -t infrastructure/"$stack"/template.yaml \
   -p infrastructure/"$stack"/envs/common.yaml \
   -p infrastructure/"$stack"/envs/"$env".yaml

--- a/script/test.sh
+++ b/script/test.sh
@@ -12,23 +12,23 @@ for file in $docker_compose_files; do
 done
 
 cleanup() {
-  docker-compose -f docker-compose-tests.yml rm -fv  || true
-  docker-compose -f docker-compose-test-different-env-var-names.yml rm -fv || true
+  docker compose -f docker-compose-tests.yml rm -fv  || true
+  docker compose -f docker-compose-test-different-env-var-names.yml rm -fv || true
 }
 trap cleanup EXIT
 
 cleanup
 
-docker-compose -f docker-compose-tests.yml up --build --abort-on-container-exit --exit-code-from sut --remove-orphans
+docker compose -f docker-compose-tests.yml up --build --abort-on-container-exit --exit-code-from sut --remove-orphans
 cleanup
 
 export PACT_BROKER_BASIC_AUTH_USERNAME=foo
 export PACT_BROKER_BASIC_AUTH_PASSWORD=bar
 export PACT_BROKER_PUBLIC_HEARTBEAT=true
-docker-compose -f docker-compose-tests.yml up --build --abort-on-container-exit --exit-code-from sut --remove-orphans
+docker compose -f docker-compose-tests.yml up --build --abort-on-container-exit --exit-code-from sut --remove-orphans
 
 unset PACT_BROKER_BASIC_AUTH_USERNAME
 unset PACT_BROKER_BASIC_AUTH_PASSWORD
 unset PACT_BROKER_PUBLIC_HEARTBEAT
 
-docker-compose -f docker-compose-test-different-env-var-names.yml up --build --abort-on-container-exit --exit-code-from sut --remove-orphans
+docker compose -f docker-compose-test-different-env-var-names.yml up --build --abort-on-container-exit --exit-code-from sut --remove-orphans


### PR DESCRIPTION
```
ERROR: for pact-broker  'ContainerConfig'
KeyError: 'ContainerConfig'
```

Transpires `docker-compose` is deprecated. I didn't get the memo 😅 

https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

That is why CI was 💔 instead of 💚 

![Screenshot 2024-06-25 at 16 01 24](https://github.com/pact-foundation/pact-broker-docker/assets/19932401/bebdcc72-76a5-4ebf-b702-957b073e20e3)
