### PR TITLE
chore(ci): prevent duplicate ci triggers

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,6 +3,8 @@ name: Audit
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
   schedule:
     - cron: 0 0 * * 4 # Midnight Wednesday
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@ name: Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Triggering on all 'push' and 'pull_request' events will result in duplicated CI runs in PRs (due to both conditions being met).

Instead, trigger only on pushes to `master`, or updates to PRs targetting `master`.