### PR TITLE
ci: audit on ubuntu-24.04-arm runner

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,19 +10,23 @@ on:
 
 jobs:
   audit:
-    name: 👮 cross-audit
+    name: 👮 audit
     strategy:
       fail-fast: false
       matrix:
-        DOCKER_TARGET_PLATFORM: [linux/arm64, linux/amd64]
-    runs-on: ubuntu-latest
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
+    runs-on: ${{ matrix.os }}
     env:
-      DOCKER_TARGET_PLATFORM: ${{ matrix.DOCKER_TARGET_PLATFORM }}
-      TAG: "latest"
+      TAG: latest
     steps:
       - uses: actions/checkout@v4
-      - name: Prepare Docker multi-arch builder for ${{ matrix.DOCKER_TARGET_PLATFORM }}
-        if: ${{ matrix.DOCKER_TARGET_PLATFORM }} == 'linux/arm' || 'linux/arm64'
-        run: ./script/release-workflow/docker-prepare.sh
-      - name: Audit Docker image for ${{ matrix.DOCKER_TARGET_PLATFORM }}
+      - name: Audit Docker image for amd64
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./script/release-workflow/audit.sh
+        env:
+          DOCKER_TARGET_PLATFORM: linux/amd64
+      - name: Audit Docker image for arm64
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
+        run: ./script/release-workflow/audit.sh
+        env:
+          DOCKER_TARGET_PLATFORM: linux/arm64


### PR DESCRIPTION
Arm runners now available, so may as well use them for the audit runs to speed them up

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Need to also apply to the main publishing runs to take advantage of the native arm64 runners