### PR TITLE
fix: Update Trivy setup action version to v0.2.6

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Manual Trivy Setup
-        uses: aquasecurity/setup-trivy@v0.2.4
+        uses: aquasecurity/setup-trivy@ve07451d2e059ed86c2870430ea286b3a9e0bf241 #v0.2.6
         with:
           cache: true
       - name: Audit Docker image for amd64


### PR DESCRIPTION
The third party action was pinned to a compromised version, the release of  which has been removed and is causing the audit pipeline to fail: https://github.com/pact-foundation/pact-broker-docker/actions/runs/24487795586

This pr pins the action to the commit sha of the only currently valid release per the docs: https://github.com/aquasecurity/setup-trivy

Further rumination steps may be required by maintainers: https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/