### PR TITLE
docs: add Scarf telemetry pixel and route pulls through Scarf gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="unreleased"></a>
+### Unreleased
+
+#### Features
+
+* add Scarf analytics pixel to README and document telemetry / opt-out
+
 <a name="2.139.0-pactbroker2.119.0"></a>
 ### 2.139.0-pactbroker2.119.0 (2026-06-17)
 

--- a/README.md
+++ b/README.md
@@ -323,11 +323,7 @@ See the [Troubleshooting][troubleshooting] page on the docs site.
 
 ## Anonymized analytics
 
-`pactfoundation/pact-broker` uses [Scarf](https://scarf.sh/) to collect anonymized analytics about how the image is being used.
-
-When you pull through the Scarf gateway (the pull commands shown throughout this README), Scarf records [**system and OS statistics, company information, and downloads by versions/tags**](https://docs.scarf.sh/packages/) — derived from your Docker client's User-Agent and an ASN lookup on your IP at request time. When you view this README on github.com or Docker Hub, a [1x1 pixel](https://docs.scarf.sh/web-traffic/) records a coarse-grained impression with country and organisation attribution. **No IP address is stored, no cookies are set, and no other personally identifiable information is retained.**
-
-To opt out of pull-event analytics, pull the image directly from Docker Hub:
+`pactfoundation/pact-broker` uses [Scarf](https://scarf.sh/) to collect [anonymized download analytics](https://about.scarf.sh/about). These analytics help support the maintainers of this image and ONLY run when you pull the image through the Scarf gateway (the pull commands shown throughout this README). To opt out, pull the image directly from Docker Hub:
 
 ```sh
 docker pull pactfoundation/pact-broker

--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ docker pull pactfoundation/pact-broker
 
 Alternatively, block `static.scarf.sh` at the network level (or disable image loading in your browser when viewing this README) to disable the README impression pixel.
 
+For more information, see [docs.pact.io/telemetry](https://docs.pact.io/telemetry).
+
 [docker]: https://docs.docker.com/install/
 [pact-broker]: https://github.com/pact-foundation/pact_broker
 [pact-broker-docker]: https://hub.docker.com/r/pactfoundation/pact-broker/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This repository contains a Dockerized version of the [Pact Broker][pact-broker].
 [![size: arm64](https://badgen.net/docker/size/pactfoundation/pact-broker/latest-multi/arm64?icon=docker&label=size%3Aarm64)](https://hub.docker.com/r/pactfoundation/pact-broker)
 [![size: arm](https://badgen.net/docker/size/pactfoundation/pact-broker/latest-multi/arm?icon=docker&label=size%3Aarm)](https://hub.docker.com/r/pactfoundation/pact-broker)
 
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f0adca49-1631-4f0b-8914-366ea390b5c8" />
+
 ## In a hurry?
 
 If you want to try out a Pact Broker that can be accessed by all your teams, without having to fill in requisition forms and wait for 3 months, you can get a free trial at <a href="https://pactflow.io/?utm_source=github&utm_campaign=pact_foundation_pact_broker_docker">pactflow.io</a>. Built by a group of core Pact maintainers, PactFlow is a fork of the OSS Pact Broker with extra goodies like an improved UI, user and team management, secrets, field level verification results and federated login. It's also fully supported, and that means when something goes wrong, *someone else* gets woken up in the middle of the afternoon to fix it...
@@ -36,7 +38,7 @@ Multi-platform images are available
 - `--platform=linux/arm64`
 
   ```sh
-  docker run --rm -it --entrypoint /bin/sh pactfoundation/pact-broker:latest -c 'uname -sm'
+  docker run --rm -it --entrypoint /bin/sh docker.pactflow.io/pactfoundation/pact-broker:latest -c 'uname -sm'
   ```
 
 ## Prerequisites
@@ -276,7 +278,7 @@ docker run --rm \
     -e PACT_BROKER_DATABASE_URL=<url> \
     -e PACT_BROKER_MIGRATION_TARGET=<target> \
     --entrypoint db-migrate \
-    pactfoundation/pact-broker
+    docker.pactflow.io/pactfoundation/pact-broker
 ```
 
 To get the current version of the database run:
@@ -285,7 +287,7 @@ To get the current version of the database run:
 docker run --rm \
     -e PACT_BROKER_DATABASE_URL=<url> \
     --entrypoint db-version \
-    pactfoundation/pact-broker
+    docker.pactflow.io/pactfoundation/pact-broker
 ```
 # Vulnerability scanning
 
@@ -318,6 +320,16 @@ Until May 2023, the versioning scheme used the `M.m.p` from the Pact Broker gem,
 # Troubleshooting
 
 See the [Troubleshooting][troubleshooting] page on the docs site.
+
+## Anonymized analytics
+
+`pactfoundation/pact-broker` uses [Scarf](https://scarf.sh/) to collect [anonymized download analytics](https://about.scarf.sh/about). These analytics help support the maintainers of this image and ONLY run when you pull the image through the Scarf gateway (the pull commands shown throughout this README). To opt out, pull the image directly from Docker Hub:
+
+```sh
+docker pull pactfoundation/pact-broker
+```
+
+Alternatively, block `static.scarf.sh` at the network level (or disable image loading in your browser when viewing this README) to disable the README impression pixel.
 
 [docker]: https://docs.docker.com/install/
 [pact-broker]: https://github.com/pact-foundation/pact_broker

--- a/README.md
+++ b/README.md
@@ -323,7 +323,11 @@ See the [Troubleshooting][troubleshooting] page on the docs site.
 
 ## Anonymized analytics
 
-`pactfoundation/pact-broker` uses [Scarf](https://scarf.sh/) to collect [anonymized download analytics](https://about.scarf.sh/about). These analytics help support the maintainers of this image and ONLY run when you pull the image through the Scarf gateway (the pull commands shown throughout this README). To opt out, pull the image directly from Docker Hub:
+`pactfoundation/pact-broker` uses [Scarf](https://scarf.sh/) to collect anonymized analytics about how the image is being used.
+
+When you pull through the Scarf gateway (the pull commands shown throughout this README), Scarf records [**system and OS statistics, company information, and downloads by versions/tags**](https://docs.scarf.sh/packages/) — derived from your Docker client's User-Agent and an ASN lookup on your IP at request time. When you view this README on github.com or Docker Hub, a [1x1 pixel](https://docs.scarf.sh/web-traffic/) records a coarse-grained impression with country and organisation attribution. **No IP address is stored, no cookies are set, and no other personally identifiable information is retained.**
+
+To opt out of pull-event analytics, pull the image directly from Docker Hub:
 
 ```sh
 docker pull pactfoundation/pact-broker

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains a Dockerized version of the [Pact Broker][pact-broker].
 [![size: arm64](https://badgen.net/docker/size/pactfoundation/pact-broker/latest-multi/arm64?icon=docker&label=size%3Aarm64)](https://hub.docker.com/r/pactfoundation/pact-broker)
 [![size: arm](https://badgen.net/docker/size/pactfoundation/pact-broker/latest-multi/arm?icon=docker&label=size%3Aarm)](https://hub.docker.com/r/pactfoundation/pact-broker)
 
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f0adca49-1631-4f0b-8914-366ea390b5c8" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=f0adca49-1631-4f0b-8914-366ea390b5c8&page=README.md" />
 
 ## In a hurry?
 


### PR DESCRIPTION
## Summary

- Routes the `docker run` commands in the README through the Scarf Docker gateway at `docker.pactflow.io/pactfoundation/pact-broker`, so image pulls from the documented examples are counted by default. The canonical `docker pull pactfoundation/pact-broker` is now the documented opt-out, mirroring the [swagger-ui anonymized-analytics](https://github.com/swagger-api/swagger-ui#anonymized-analytics) pattern.
- Adds a Scarf README pixel (HTML `<img>` form with `referrerpolicy="no-referrer-when-downgrade"`) using pixel UUID `f0adca49-1631-4f0b-8914-366ea390b5c8`.
- Adds an `## Anonymized analytics` section disclosing what's collected and how to opt out.
- CHANGELOG entry under `Unreleased`.

No application, image, or CI changes. Pact-Foundation maintainers' Scarf account owns the gateway and pixel.

Part of [PACT-6978](https://smartbear.atlassian.net/browse/PACT-6978) under epic [PACT-6977](https://smartbear.atlassian.net/browse/PACT-6977) (Scarf rollout across the Pact Broker repos).

## Test plan

- [ ] Confirm the rendered README on github.com shows the analytics section and the pixel (invisible 1x1).
- [ ] Confirm Docker Hub README impressions register on the Scarf dashboard.
- [ ] Confirm pulls via `docker run --rm -it --entrypoint /bin/sh docker.pactflow.io/pactfoundation/pact-broker:latest -c 'uname -sm'` complete successfully and appear on the Scarf Docker Package.
- [ ] Confirm the canonical `docker pull pactfoundation/pact-broker` continues to work unchanged for users who opt out.